### PR TITLE
feat: Adicionar suporte para outros idiomas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@
 # production
 /build
 
+# file
+/package-lock.json
+
 # misc
 .DS_Store
 *.pem

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "autoprefixer": "10.4.15",
     "eslint-config-next": "13.4.19",
     "framer-motion": "^10.16.4",
+    "i18next": "^23.5.1",
+    "i18next-browser-languagedetector": "^7.1.0",
     "next": "13.4.19",
     "phosphor-react": "^1.4.1",
     "postcss": "8.4.29",

--- a/src/app/components/header/data.ts
+++ b/src/app/components/header/data.ts
@@ -1,22 +1,23 @@
+import { i18n } from "@/translate/i18n";
 export const MENU = [
   {
     id: 1,
-    text: "Início",
+    text: i18n.t('nav.link_1'),
     url: "top",
   },
   {
     id: 2,
-    text: "Motivações",
+    text: i18n.t('nav.link_2'),
     url: "motivations",
   },
   {
     id: 3,
-    text: "AOSC Mentorship",
+    text: i18n.t('nav.link_3'),
     url: "program",
   },
   {
     id: 4,
-    text: "Equipa",
+    text: i18n.t('nav.link_4'),
     url: "our-team",
   },
   {

--- a/src/app/components/header/index.tsx
+++ b/src/app/components/header/index.tsx
@@ -1,10 +1,26 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Logo from "./logo";
 import Menu from "./menu";
 import ButtonLink from "../buttonLink";
 import { MENU } from "./data";
+import { i18n } from "@/translate/i18n";
+
+const I18N_KEY = "i18nextLng";
 
 function Header({ ...rest }) {
+  const [language, setLanguage] = useState<any>('pt-BR')
+
+  const handleChangeLanguage = (value:any)=>{
+      localStorage.setItem('i18nextLng', value)
+      window.location.reload()
+  }
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.localStorage) {
+        setLanguage(localStorage.getItem(I18N_KEY))
+    }
+  }, []);
+
   return (
     <header
       className="w-full flex-col items-center justify-center px-6 hidden lg:flex fixed top-10 bg-white z-50"
@@ -13,10 +29,14 @@ function Header({ ...rest }) {
       <div className="w-full max-w-[1216px] py-4 flex items-center justify-between">
         <Logo />
         <Menu items={MENU} />
+        <select style={{outline:'none', cursor:'pointer'}} onChange={(e)=>handleChangeLanguage(e.target.value)} value={language}>
+          <option value="en-US">English</option>
+          <option value="pt-BR">Português</option>
+        </select>
         <ButtonLink
           href={"https://opencollective.com/aosc"}
           target="_blank"
-          text={"Faça uma doação"}
+          text={i18n.t('nav.button')}
         />
       </div>
       <hr />

--- a/src/app/components/headline/index.tsx
+++ b/src/app/components/headline/index.tsx
@@ -4,6 +4,7 @@ import ButtonLink from "../buttonLink";
 import Link from "next/link";
 import { Link as LinkScroll } from "react-scroll";
 import Image from "next/image";
+import { i18n } from "@/translate/i18n";
 
 function Headline({ ...rest }) {
   return (
@@ -18,21 +19,17 @@ function Headline({ ...rest }) {
           // animate={{ opacity: 1 }}
           // transition={{ duration: 0.5 }}
         >
-          Criando um impacto{" "}
-          <br className="hidden xl:block" /> significativo
-          na inovação tecnológica do país.
+          {i18n.t('headline.title')}
         </motion.h1>
         <p className="md:text-xl text-sm text-[#646464] leading-[150%] font-medium text-center max-w-3xl xl:text-start">
-          A nossa missão é promover o desenvolvimento e
-          adoção de Free and Open-source Software(FOSS) em
-          Angola.
+          {i18n.t('headline.description')}
         </p>
         <div className="flex items-center gap-4 flex-col min-[420px]:flex-row">
           <ButtonLink
             href={
               "https://linktr.ee/angolaosc"
             }
-            text={"Juntar-me a comunidade"}
+            text={i18n.t('headline.button')}
             target="_blank"
           />
           <LinkScroll
@@ -42,7 +39,7 @@ function Headline({ ...rest }) {
             delay={0.8}
             className="cursor-pointer hover:no-underline text-gray-500 hover:text-red-600"
           >
-            Saiba Mais
+            {i18n.t('headline.link')}
           </LinkScroll>
         </div>
         <div className="flex items-center gap-2 flex-col-reverse xl:flex-row">
@@ -84,7 +81,7 @@ function Headline({ ...rest }) {
             />
           </div>
           <span className="text-base font-semibold">
-            Junte-se a mais de 2,700 membros
+            {i18n.t('headline.info')}
           </span>
         </div>
       </div>
@@ -111,7 +108,7 @@ function Headline({ ...rest }) {
             bottom: 50,
           }}
         >
-          Software Livre
+         {i18n.t('headline.bloom_1')}
         </motion.span>
         <motion.span
           className="bg-yellow-300 absolute top-[80%] right-48 text-black font-bold text-base rounded-full px-4 py-3 cursor-pointer z-30"
@@ -123,7 +120,7 @@ function Headline({ ...rest }) {
             bottom: 50,
           }}
         >
-          Colaboração
+         {i18n.t('headline.bloom_2')}
         </motion.span>
         <Image
           src={"/hero.png"}

--- a/src/app/components/motivations/data.ts
+++ b/src/app/components/motivations/data.ts
@@ -1,3 +1,4 @@
+import { i18n } from "@/translate/i18n";
 export const MOTIVATIONS = [
   {
     id: 1,

--- a/src/app/components/tape/index.tsx
+++ b/src/app/components/tape/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { twMerge } from "tailwind-merge";
+import { i18n } from "@/translate/i18n";
 
 interface TapeProps {
   className?: string;
@@ -33,19 +34,19 @@ function Tape({
             <ul className="flex gap-4 md:gap-8">
               <li>Open Source</li>
               <li>.</li>
-              <li>Software Livre</li>
+              <li>{i18n.t('tape.text_2')}</li>
               <li>.</li>
-              <li>Comunidade</li>
+              <li>{i18n.t('tape.text_1')}</li>
               <li>.</li>
-              <li>Colaboração</li>
+              <li>{i18n.t('tape.text_3')}</li>
               <li>.</li>
               <li>Open Source</li>
               <li>.</li>
-              <li>Software Livre</li>
+              <li>{i18n.t('tape.text_2')}</li>
               <li>.</li>
-              <li>Comunidade</li>
+              <li>{i18n.t('tape.text_1')}</li>
               <li>.</li>
-              <li>Colaboração</li>
+              <li>{i18n.t('tape.text_3')}</li>
             </ul>
           </span>
         ))}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import Program from "./components/program";
 import MobileHeader from "./components/header/mobile";
 import { MENU } from "./components/header/data";
 import Footer from "./components/footer";
+import { i18n } from "@/translate/i18n";
 
 export default function Home() {
   return (
@@ -21,9 +22,7 @@ export default function Home() {
       <div className="gap-2 items-center justify-center pointer-events-none select-none z-50 fixed top-0 bg-violet-600 right-0 left-0 p-6 py-2 hidden lg:flex">
         <i>🇦🇴</i>
         <span className="text-white">
-          {" "}
-          Participe agora do primeiro evento presencial da
-          Angola Open Source Community em Luanda.
+        {i18n.t('heading.info')}
         </span>
       </div>
 
@@ -41,7 +40,7 @@ export default function Home() {
       <Element name="purposes">
         <Purpose
           data={PURPOSES}
-          title="Nossos principais objetivos"
+          title={i18n.t('goal.title')}
           className="py-52"
         />
       </Element>

--- a/src/translate/i18n.ts
+++ b/src/translate/i18n.ts
@@ -1,0 +1,16 @@
+import i18n from 'i18next'
+import LanguageDetector from 'i18next-browser-languagedetector'
+
+import { messages } from './languages'
+
+i18n
+    .use(LanguageDetector)
+    .init({
+        debug: false,
+        defaultNS: ['translations'],
+        fallbackLng: 'pt-BR',
+        ns: ['translations'],
+        resources: messages
+    })
+
+export { i18n }

--- a/src/translate/languages/en.ts
+++ b/src/translate/languages/en.ts
@@ -1,0 +1,53 @@
+const messages = {
+    en: {
+        translations: {
+            titles: {
+                app: 'My application: {{name}}'
+            },
+            heading: {
+                info: 'Take part now in the first face-to-face event of the Angola Open Source Commnunity in Luanda.',
+                smallText: 'A small text'
+            },
+            nav: {
+               link_1 : 'Home',
+               link_2 : 'Mentorship Program',
+               link_3 : 'Team',
+               link_4 : 'Event',
+               link_5 : 'Motivations',
+               button : 'Donate'
+            },
+            headline:{
+                title :`Creating a significant impact, on technological innovation in the country.`,
+                description : 'Our mission is to promote the development and adoption of Free and Open-source Software (FOSS) in Angola.',
+                button : 'Join the community',
+                link : 'Learn more',
+                info :'Join 200+ members',
+                bloom_1 : 'Free Software',
+                bloom_2 : 'Collaboration'
+
+             },
+             tape:{
+                text_1 : "Community",
+                text_2 : 'Free Software',
+                text_3 : 'Collaboration'
+             },
+             goal:{
+                title : "Our main goals",
+                section_1 :{
+                    title : 'Encouraging a free software culture.',
+                    description : 'Promote awareness of the benefits of open source software and encourage its use in Angola.'
+                },
+                section_2 :{
+                    title : 'Accelerate open source development.',
+                    description : 'Offer resources and mentoring programs, workshops, and other events to help Angolan developers learn and contribute to excel in open source.'
+                },
+                section_3 :{
+                    title : 'Establish partnerships and collaborations.',
+                    description : 'To strengthen the free software community in Angola by facilitating the exchange of knowledge, resources and experiences between developers.'
+                },   
+             }
+        }
+    }
+}
+
+export { messages }

--- a/src/translate/languages/index.ts
+++ b/src/translate/languages/index.ts
@@ -1,0 +1,9 @@
+import { messages as portugueseMessages } from './pt'
+import { messages as englishMessages } from './en'
+
+const messages = {
+    ...portugueseMessages,
+    ...englishMessages
+}
+
+export { messages }

--- a/src/translate/languages/pt.ts
+++ b/src/translate/languages/pt.ts
@@ -1,0 +1,53 @@
+const messages = {
+    pt: {
+        translations: {
+            titles: {
+                app: 'Minha aplicação: {{name}}'
+            },
+            heading: {
+                info: 'Participe agora do primeiro evento presencial da Angola Open Source Commnunity em Luanda.',
+            },
+            nav: {
+                link_1 : 'Inicio',
+                link_2 : 'Programa de Mentoria',
+                link_3 : 'Equipa',
+                link_4 : 'Evento',
+                link_5 : 'Motivações',
+                button : 'Faça uma doação'
+             },
+             headline:{
+                title:"Criando um impacto significativo na inovação tecnológica do país.",
+                description: 'A nossa missão é promover o desenvolvimento e adoção de Free and Open-source Software(FOSS) em Angola.',
+                button: 'Juntar-me a comunidade',
+                link: 'Saber mais',
+                info:'Junte-se a mais de 200 membros',
+                bloom_1: 'Software Livre',
+                bloom_2: 'Colaboração'
+             },
+             tape:{
+                text_1 : "Comunidade",
+                text_2: 'Software Livre',
+                text_3: 'Colaboração'
+             },
+             goal:{
+                title : "Nossos principais objetivos",
+                section_1 :{
+                    title : 'Fomentar a cultura do software livre.',
+                    description : 'Promover a conscientização sobre os benefícios do software de código aberto e incentivar seu uso em Angola.'
+                },
+                section_2 :{
+                    title : 'Acelerar o desenvolvimento de código aberto.',
+                    description : 'Oferecer recursos e programas de mentoria, workshops, e outros eventos para ajudar o desenvolvedor angolano aprender, e contribuir a se destacar no código aberto.'
+                },
+                section_3 :{
+                    title : 'Estabelecer parcerias e colaborações.',
+                    description : 'Fortalecer a comunidade de software livre em Angola, facilitando a troca de conhecimento, recursos e experiências entre desenvolvedores.'
+                },   
+        }
+        
+    }
+}
+}
+
+
+export { messages }

--- a/src/utils/data/purposes.tsx
+++ b/src/utils/data/purposes.tsx
@@ -1,4 +1,5 @@
 import { Brain, Coffee, Confetti } from "phosphor-react";
+import { i18n } from "@/translate/i18n";
 
 export const PURPOSES = [
   {
@@ -6,16 +7,16 @@ export const PURPOSES = [
     Icon: (
       <Brain weight="duotone" size={40} color="#FE5C5C" />
     ),
-    title: "Fomentar a cultura do software livre.",
-    body: "Promover a conscientização sobre os benefícios do software de código aberto e incentivar seu uso em Angola.",
+    title: i18n.t('goal.section_1.title'),
+    body: i18n.t('goal.section_1.description'),
   },
   {
     id: 2,
     Icon: (
       <Coffee weight="duotone" size={40} color="#FE5C5C" />
     ),
-    title: "Acelerar o desenvolvimento de código aberto.",
-    body: "Oferecer recursos e programas de mentoria, workshops, e outros eventos para ajudar o desenvolvedor angolano aprender, e contribuir a se destacar no código aberto.",
+    title: i18n.t('goal.section_2.title'),
+    body: i18n.t('goal.section_2.description'),
   },
   {
     id: 3,
@@ -26,7 +27,7 @@ export const PURPOSES = [
         color="#FE5C5C"
       />
     ),
-    title: "Estabelecer parcerias e colaborações.",
-    body: "Fortalecer a comunidade de software livre em Angola, facilitando a troca de conhecimento, recursos e experiências entre desenvolvedores.",
+    title: i18n.t('goal.section_3.title'),
+    body: i18n.t('goal.section_3.description'),
   },
 ];


### PR DESCRIPTION
## Team Debuguers
Adicionou-se suporte para outros idiomas (Português / Inglês) com a biblioteca i18n.
### Secção traduzidas
- header
- menu
- headline
- tape
- objectivos

Adicionou-se também um <b>select option</b> para poder selecionar o idioma preferido, o select option será customizado, mas demomento está se dando prioridade nas traduções. As outras secções também serão traduzidas em breve, para posterior Adicionar suporte ao idioma Francês.

Essa implementação, é para solucionar a issue #8

@aosccode