### PR TITLE
feat:adicionar tema dark mode

### DIFF
--- a/src/app/components/footer/index.tsx
+++ b/src/app/components/footer/index.tsx
@@ -24,11 +24,11 @@ function Footer({ ...rest }) {
                   width={80}
                   height={80}
                 />
-                <h3 className="sm:text-3xl text-2xl font-bold">
+                <h3 className="dark:text-slate-400 sm:text-3xl text-2xl font-bold">
                   Angola OpenSource Community
                 </h3>
               </div>
-              <p className=" w-72">
+              <p className="dark:text-slate-400 w-72">
                 We aim to develop and promote FOSS in
                 Angola.
               </p>
@@ -36,19 +36,21 @@ function Footer({ ...rest }) {
             <ButtonLink
               href="mailto:info@aosc.social"
               text="Fale conosco"
-              className="text-center justify-center items-center w-56"
+              className="dark:bg-btn dark:text-btc text-center justify-center items-center w-56"
             />
           </div>
           <div className="flex flex-row flex-wrap gap-6">
             <div className="w-52">
-              <h3 className="text-xl">AOSC</h3>
+              <h3 className="text-xl dark:text-white">
+                AOSC
+              </h3>
               <ul className="flex flex-col">
                 <li>
                   <Link
                     to={"top"}
                     smooth={true}
                     duration={1400}
-                    className=" hover:text-black transition-colors duration-[0.3s] ease-linear cursor-pointer"
+                    className="dark:text-sky-400 hover:text-black transition-colors duration-[0.3s] ease-linear cursor-pointer"
                   >
                     Início
                   </Link>
@@ -58,7 +60,7 @@ function Footer({ ...rest }) {
                     to={"motivations"}
                     smooth={true}
                     duration={1400}
-                    className=" hover:text-black transition-colors duration-[0.3s] ease-linear cursor-pointer"
+                    className="dark:text-sky-400 hover:text-black transition-colors duration-[0.3s] ease-linear cursor-pointer"
                   >
                     Motivações
                   </Link>
@@ -68,7 +70,7 @@ function Footer({ ...rest }) {
                     to={"our-team"}
                     smooth={true}
                     duration={1400}
-                    className=" hover:text-black transition-colors duration-[0.3s] ease-linear cursor-pointer"
+                    className="dark:text-sky-400 hover:text-black transition-colors duration-[0.3s] ease-linear cursor-pointer"
                   >
                     Equipa
                   </Link>
@@ -77,7 +79,7 @@ function Footer({ ...rest }) {
                   <NextLink
                     href={"https://fest.aosc.social/"}
                     target="_blank"
-                    className=" hover:text-black transition-colors duration-[0.3s] ease-linear"
+                    className="dark:text-sky-400 hover:text-black transition-colors duration-[0.3s] ease-linear"
                   >
                     AOSFest 2023
                   </NextLink>
@@ -86,7 +88,9 @@ function Footer({ ...rest }) {
             </div>
 
             <div className="w-52">
-              <h3 className="text-xl">Comunidades</h3>
+              <h3 className="text-xl dark:text-white">
+                Comunidades
+              </h3>
               <ul className="flex flex-col">
                 <li>
                   <NextLink
@@ -94,7 +98,7 @@ function Footer({ ...rest }) {
                       "https://discord.com/invite/tuUDNdRzvz"
                     }
                     target="_blank"
-                    className=" hover:text-black transition-colors duration-[0.3s] ease-linear"
+                    className="dark:text-sky-400 hover:text-black transition-colors duration-[0.3s] ease-linear"
                   >
                     Discord
                   </NextLink>
@@ -105,7 +109,7 @@ function Footer({ ...rest }) {
                       "https://www.facebook.com/aoscangola"
                     }
                     target="_blank"
-                    className=" hover:text-black transition-colors duration-[0.3s] ease-linear"
+                    className="dark:text-sky-400 hover:text-black transition-colors duration-[0.3s] ease-linear"
                   >
                     Facebook
                   </NextLink>
@@ -116,7 +120,7 @@ function Footer({ ...rest }) {
                       "https://www.linkedin.com/company/angola-open-source-community"
                     }
                     target="_blank"
-                    className=" hover:text-black transition-colors duration-[0.3s] ease-linear"
+                    className="dark:text-sky-400 hover:text-black transition-colors duration-[0.3s] ease-linear"
                   >
                     Linkedin
                   </NextLink>
@@ -127,7 +131,7 @@ function Footer({ ...rest }) {
                       "https://www.youtube.com/@angolaosc"
                     }
                     target="_blank"
-                    className=" hover:text-black transition-colors duration-[0.3s] ease-linear"
+                    className="dark:text-sky-400 hover:text-black transition-colors duration-[0.3s] ease-linear"
                   >
                     Youtube
                   </NextLink>
@@ -135,13 +139,15 @@ function Footer({ ...rest }) {
               </ul>
             </div>
             <div className="w-52">
-              <h3 className="text-xl">Projectos</h3>
+              <h3 className="text-xl dark:text-white">
+                Projectos
+              </h3>
               <ul className="flex flex-col">
                 <li>
                   <NextLink
                     href={"https://mentorship.aosc.social"}
                     target="_blank"
-                    className=" hover:text-black transition-colors duration-[0.3s] ease-linear"
+                    className="dark:text-sky-400 hover:text-black transition-colors duration-[0.3s] ease-linear"
                   >
                     Programa de Mentoria
                   </NextLink>
@@ -152,7 +158,7 @@ function Footer({ ...rest }) {
                       "https://www.youtube.com/playlist?list=PLso4Zv7njkDM-AjI3Z0oaFcPZdT7-fmLy"
                     }
                     target="_blank"
-                    className=" hover:text-black transition-colors duration-[0.3s] ease-linear"
+                    className="dark:text-sky-400 hover:text-black transition-colors duration-[0.3s] ease-linear"
                   >
                     The Open Source Café(TOSCA)
                   </NextLink>
@@ -162,7 +168,7 @@ function Footer({ ...rest }) {
           </div>
         </div>
         <div className="flex justify-center items-center w-full py-6 border-t flex-col gap-6 md:flex-row md:justify-between">
-          <p className=" text-center md:text-start">
+          <p className="dark:text-slate-400 text-center md:text-start">
             © {year} - Angola Open Source Communiy.
             <br />
             Todos os direitos reservados.
@@ -170,6 +176,7 @@ function Footer({ ...rest }) {
             <NextLink
               target="_blank"
               href="https://github.com/angolaosc/aosc.social"
+              className="dark:text-sky-400"
             >
               {" "}
               ver código fonte,{" "}
@@ -178,13 +185,14 @@ function Footer({ ...rest }) {
             <NextLink
               target="_blank"
               href="https://github.com/angolaosc/aosf-website/blob/main/LICENSE"
+              className="dark:text-sky-400"
             >
               Licença Apache-2.0
             </NextLink>
           </p>
           <button
             onClick={() => animateScroll.scrollToTop()}
-            className=" hover:text-black transition-colors duration-[0.3s] ease-linear"
+            className="dark:text-white hover:text-black transition-colors duration-[0.3s] ease-linear"
           >
             Voltar ao topo
           </button>

--- a/src/app/components/header/index.tsx
+++ b/src/app/components/header/index.tsx
@@ -3,17 +3,20 @@ import Logo from "./logo";
 import Menu from "./menu";
 import ButtonLink from "../buttonLink";
 import { MENU } from "./data";
+import ThemeSwitcher from "../theme";
 
 function Header({ ...rest }) {
   return (
     <header
-      className="w-full flex-col items-center justify-center px-6 hidden lg:flex fixed top-10 bg-white z-50"
+      className="dark:bg-bgd  w-full flex-col items-center justify-center px-6 hidden lg:flex fixed top-10 bg-white z-50"
       {...rest}
     >
       <div className="w-full max-w-[1216px] py-4 flex items-center justify-between">
         <Logo />
         <Menu items={MENU} />
+        <ThemeSwitcher/>
         <ButtonLink
+          className="dark:bg-btn dark:text-btc"
           href={"https://opencollective.com/aosc"}
           target="_blank"
           text={"Faça uma doação"}

--- a/src/app/components/header/logo.tsx
+++ b/src/app/components/header/logo.tsx
@@ -16,7 +16,7 @@ function Logo() {
         width={32}
         height={32}
       />
-      <h3 className="text-sm font-semibold leading-4 text-black">
+      <h3 className="dark:text-slate-400 text-sm font-semibold leading-4 text-black">
         Angola OpenSource Community
       </h3>
     </Link>

--- a/src/app/components/header/menu.tsx
+++ b/src/app/components/header/menu.tsx
@@ -22,13 +22,13 @@ function Menu({ items }: MenuProps) {
               <NextLink
                 href={url}
                 target="_blank"
-                className="text-gray-500 cursor-pointer hover:text-red-600 duration-300 ease-in hover:no-underline"
+                className="dark:text-link text-gray-500 cursor-pointer hover:text-red-600 duration-300 ease-in hover:no-underline dark:hover:text-lhover"
               >
                 {text}
               </NextLink>
             ) : (
               <Link
-                className="text-gray-500 cursor-pointer hover:text-red-600 duration-300 ease-in hover:no-underline"
+                className="dark:text-link text-gray-500 cursor-pointer hover:text-red-600 duration-300 ease-in hover:no-underline dark:hover:text-lhover"
                 smooth={true}
                 duration={1400}
                 to={url}

--- a/src/app/components/header/mobile.tsx
+++ b/src/app/components/header/mobile.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import Logo from "./logo";
 import { Link } from "react-scroll";
 import NextLink from "next/link";
+import ThemeSwitcher from "../theme";
 
 type MenuItem = {
   id: number;
@@ -17,9 +18,10 @@ function MobileHeader({ items }: MenuProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <div className="bg-white text-white w-full fixed z-50 lg:hidden top-0">
+    <div className="dark:bg-bgd bg-white text-white w-full fixed z-50 lg:hidden top-0">
       <div className="p-6 flex justify-between items-center shadow-md">
         <Logo />
+        <ThemeSwitcher/>
         <button onClick={() => setIsOpen(!isOpen)}>
           <svg
             className="w-8 h-8"
@@ -39,7 +41,7 @@ function MobileHeader({ items }: MenuProps) {
       </div>
 
       {isOpen && (
-        <header className="bg-red-600 absolute left-0 right-0 h-screen p-6">
+        <header className="dark:bg-bgd bg-red-600 absolute left-0 right-0 h-screen p-6">
           <ul className="flex items-start gap-3 flex-col">
             {items.map(({ id, text, url }) => (
               <li

--- a/src/app/components/headline/index.tsx
+++ b/src/app/components/headline/index.tsx
@@ -13,7 +13,7 @@ function Headline({ ...rest }) {
     >
       <div className="max-w-[696px] w-full flex flex-col gap-5 justify-start items-center xl:items-start">
         <motion.h1
-          className="md:text-5xl text-3xl font-extrabold leading-[130%] my-element justify-start items-center text-center max-w-3xl xl:max-w-none xl:text-start"
+          className="dark:text-white md:text-5xl text-3xl font-extrabold leading-[130%] my-element justify-start items-center text-center max-w-3xl xl:max-w-none xl:text-start"
           // initial={{ opacity: 0 }}
           // animate={{ opacity: 1 }}
           // transition={{ duration: 0.5 }}
@@ -22,13 +22,14 @@ function Headline({ ...rest }) {
           <br className="hidden xl:block" /> significativo
           na inovação tecnológica do país.
         </motion.h1>
-        <p className="md:text-xl text-sm text-[#646464] leading-[150%] font-medium text-center max-w-3xl xl:text-start">
+        <p className="dark:text-slate-400 md:text-xl text-sm text-[#646464] leading-[150%] font-medium text-center max-w-3xl xl:text-start">
           A nossa missão é promover o desenvolvimento e
           adoção de Free and Open-source Software(FOSS) em
           Angola.
         </p>
         <div className="flex items-center gap-4 flex-col min-[420px]:flex-row">
           <ButtonLink
+          className="dark:bg-btn dark:text-btc"
             href={
               "https://linktr.ee/angolaosc"
             }
@@ -40,7 +41,7 @@ function Headline({ ...rest }) {
             smooth={true}
             duration={1400}
             delay={0.8}
-            className="cursor-pointer hover:no-underline text-gray-500 hover:text-red-600"
+            className=" dark:text-slate-400 cursor-pointer hover:no-underline text-gray-500 hover:text-red-600"
           >
             Saiba Mais
           </LinkScroll>
@@ -83,12 +84,12 @@ function Headline({ ...rest }) {
               height={32}
             />
           </div>
-          <span className="text-base font-semibold">
+          <span className="dark:text-slate-400 text-base font-semibold">
             Junte-se a mais de 2,700 membros
           </span>
         </div>
       </div>
-      <div className="bg-gray-200 rounded-lg w-[600px] hidden items-center justify-center relative xl:flex">
+      <div className="dark:bg-bgd bg-gray-200 rounded-lg w-[600px] hidden items-center justify-center relative xl:flex">
         <motion.span
           className="bg-red-300 absolute top-[90px] left-24 text-black font-bold text-base rounded-full px-4 py-3 cursor-pointer"
           drag

--- a/src/app/components/motivations/index.tsx
+++ b/src/app/components/motivations/index.tsx
@@ -26,7 +26,7 @@ function Motivations({ className, ...rest }: any) {
             href={"https://linktr.ee/angolaosc"}
             text={"Juntar-me a comunidade"}
             target="_blank"
-            className="md:max-w-fit w-full text-center justify-center md:justify-start"
+            className="dark:bg-btn dark:text-btc md:max-w-fit w-full text-center justify-center md:justify-start"
           />
         </div>
         <div className="max-w-[696px]">
@@ -37,7 +37,7 @@ function Motivations({ className, ...rest }: any) {
                   <h2 className="text-2xl text-white font-bold leading-[150%]">
                     {title}
                   </h2>
-                  <p className="text-base text-[#a3a3a3] font-medium leading-[150%]">
+                  <p className=" text-base text-[#a3a3a3] font-medium leading-[150%]">
                     {body}
                   </p>
                 </div>

--- a/src/app/components/our-team/index.tsx
+++ b/src/app/components/our-team/index.tsx
@@ -6,7 +6,7 @@ function OurTeam() {
   return (
     <section className="py-28 pb-96" id="team">
       <div className="flex flex-col items-center justify-center gap-12 w-full max-w-[1216px] p-6">
-        <h2 className="xl:text-5xl text-3xl font-extrabold leading-[130%] md:text-center">
+        <h2 className="dark:text-white xl:text-5xl text-3xl font-extrabold leading-[130%] md:text-center">
           Conheça o nosso core team incrível
         </h2>
         <div className="grid xl:grid-cols-4 md:grid-cols-2 lg:grid-cols-3 gap-8 w-full">
@@ -31,14 +31,14 @@ function OurTeam() {
                   style={{objectFit:'cover', objectPosition:'top'}}
                 />
                 <div className="py-8 md:pl-7 max-h-80">
-                  <p className="text-gray-500 text-base font-medium leading-[130%] lg:opacity-0 lg:max-h-0 overflow-hidden lg:group-hover:opacity-100 lg:group-hover:max-h-96 transition-all duration-300">
+                  <p className="dark:text-slate-400 text-gray-500 text-base font-medium leading-[130%] lg:opacity-0 lg:max-h-0 overflow-hidden lg:group-hover:opacity-100 lg:group-hover:max-h-96 transition-all duration-300">
                     {description}
                   </p>
                   <div className="flex gap-1 flex-col ">
-                    <h3 className="font-bold text-2xl leading-[130%]">
+                    <h3 className="dark:text-white font-bold text-2xl leading-[130%]">
                       {name}
                     </h3>
-                    <span className="text-base text-red-500 leading-[130%] font-bold uppercase">
+                    <span className="dark:text-btn   text-base text-red-500 leading-[130%] font-bold uppercase">
                       {ocupation}
                     </span>
                   </div>

--- a/src/app/components/program/index.tsx
+++ b/src/app/components/program/index.tsx
@@ -9,29 +9,29 @@ function Program() {
     <section className="py-44">
       <div className="flex items-center gap-12 w-full max-w-[1216px] p-6 flex-col-reverse xl:flex-row">
         <div className="flex flex-col xl:gap-28 gap-6">
-          <h2 className="xl:text-5xl text-3xl font-extrabold leading-[130%]">
+          <h2 className="dark:text-white xl:text-5xl text-3xl font-extrabold leading-[130%]">
             Programa de Mentoria
           </h2>
 
           <ul className="flex flex-wrap xl:w-[630px] xl:gap-10 gap-4">
             <li>
               <div className="flex xl:gap-4 gap-2 w-64 flex-col">
-                <h3 className="xl:text-3xl text-2xl font-bold leading-[120%]">
+                <h3 className="dark:text-white xl:text-3xl text-2xl font-bold leading-[120%]">
                   Workshops
                 </h3>
-                <p className="text-[#646464] xl:text-base text-sm leading-[130%]">
+                <p className="dark:text-slate-400 text-[#646464] xl:text-base text-sm leading-[130%]">
                   Inclui uma semana de workshops online e
-                  treinamentos introdutórios sobre Git e outras ferramentas essenciais 
+                  treinamentos introdutórios sobre Git e outras ferramentas essenciais
                   para o desenvolvimento de software open source.
                 </p>
               </div>
             </li>
             <li>
               <div className="flex xl:gap-4 gap-2 w-64 flex-col">
-                <h3 className="xl:text-3xl text-2xl font-bold leading-[120%]">
+                <h3 className="dark:text-white xl:text-3xl text-2xl font-bold leading-[120%]">
                 Experiência Prática
                 </h3>
-                <p className="text-[#646464] xl:text-base text-sm leading-[130%]">
+                <p className="dark:text-slate-400 text-[#646464] xl:text-base text-sm leading-[130%]">
                 Conecta mentores experientes, colaboradores talentosos
                 e organizações de software livre para contribuir para projetos de open source.
                 </p>
@@ -39,10 +39,10 @@ function Program() {
             </li>
             <li>
               <div className="flex xl:gap-4 gap-2 w-64 flex-col">
-                <h3 className="xl:text-3xl text-2xl font-bold leading-[120%]">
+                <h3 className="dark:text-white xl:text-3xl text-2xl font-bold leading-[120%]">
                   Desenvolvimento de Carreira
                 </h3>
-                <p className="text-[#646464] xl:text-base text-sm leading-[130%]">
+                <p className="dark:text-slate-400 text-[#646464] xl:text-base text-sm leading-[130%]">
                  Fornece uma base sólida de conhecimento e habilidades para desenvolvedores angolanos
                  que desejam contribuir para projetos de software livre.
                 </p>
@@ -53,7 +53,7 @@ function Program() {
             href="https://mentorship.aosc.social/"
             text="Conhecer Programa de Mentoria"
             target="_blank"
-            className="w-fit"
+            className="w-fit bg-btn dark:text-btc"
           />
         </div>
         <div className="w-full xl:w-[448px]  bg-red-500 h-[624px] rounded-xl xl:flex items-end justify-center relative hidden">

--- a/src/app/components/section-itens/index.tsx
+++ b/src/app/components/section-itens/index.tsx
@@ -30,7 +30,7 @@ function SectionItens({
       )}
       {...rest}
     >
-      <h2 className="xl:text-5xl text-3xl font-extrabold leading-[130%] md:text-center">
+      <h2 className="dark:text-white xl:text-5xl text-3xl font-extrabold leading-[130%] md:text-center">
         {title}
       </h2>
 
@@ -41,10 +41,10 @@ function SectionItens({
             className="flex flex-col gap-4  max-w-md"
           >
             {Icon}
-            <h3 className="text-black font-bold leading-[120%] xl:text-3xl text-2xl max-w-sm">
+            <h3 className="dark:text-white text-black font-bold leading-[120%] xl:text-3xl text-2xl max-w-sm">
               {title}
             </h3>
-            <p className="text-[#646464] xl:text-lg text-sm leading-[130%]">
+            <p className="dark:text-slate-400 text-[#646464] xl:text-lg text-sm leading-[130%]">
               {body}
             </p>
           </div>

--- a/src/app/components/theme/index.tsx
+++ b/src/app/components/theme/index.tsx
@@ -1,0 +1,43 @@
+import { useState, useEffect } from "react";
+import { Moon, Sun } from "phosphor-react";
+
+const ThemeSwitcher = () => {
+  const [theme, setTheme] = useState("light");
+
+  const toggleTheme = () => {
+    const newTheme = theme === "light" ? "dark" : "light";
+    setTheme(newTheme);
+    localStorage.setItem("theme", newTheme);
+    document.documentElement.classList.toggle("dark");
+  };
+
+  useEffect(() => {
+    const savedTheme = localStorage.getItem("theme");
+    if (savedTheme) {
+      setTheme(savedTheme);
+      document.documentElement.classList.toggle(
+        "dark",
+        savedTheme === "dark",
+      );
+    }
+  }, []);
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="rounded text-white"
+    >
+      {theme === "light" ? (
+        <Moon
+          size={24}
+          color={theme === "light" ? "#000000" : "#000000"}
+        />
+      ) : (
+        <Sun size={24}
+        color={theme === "light" ? "#ffffff" : "#ffffff"}/>
+      )}
+    </button>
+  );
+};
+
+export default ThemeSwitcher;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,6 +15,10 @@
   @apply text-red-600;
 }
 
+.dark body{
+  background-color: #1E293B;
+}
+
 body {
   font-family: "Lato", sans-serif;
   overflow-x: hidden;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,13 +6,22 @@ const config: Config = {
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
+  darkMode: 'class',
   theme: {
     extend: {
       backgroundImage: {
         "motivations-pattern": "url('/black-logo.svg/')",
       },
+       colors: {
+        'bgd': '#182138',
+         'link': '#ffff8a',
+         'lhover': '#ffffff',
+         'btc': '#000000',
+         "btn": "#F87171"
+      },
     },
   },
+  darkSelector: '.dark',
   plugins: [],
 };
 export default config;


### PR DESCRIPTION
# Team Debuguers

## Adicionou-se suporte para modo  dark.

### Objectivo
Adiciona a funcionalidade de dark mode ao aplicativo, permitindo que os usuários alternem entre os modos claro e escuro. Isso melhora a experiência do usuário em ambientes com pouca luz e oferece mais opções de personalização.

Essa implementação fixes #9 

Update feito com as dicas do mantedor do projecto
@Danguya 

- removemos o react-icones e usamos apenas o phosphor-react
- retiramos também uso do next-themes deixando apenas o uso do tailwind.
- utilizamos o colorZilla pra verificar e melhorar o contraste da cor , para não afetar os olhos dos usúarios!
-  por fim um componente para alternância entre os modos light e dark.
-  armazenamos o modo escolhido no localStorage assim quando usúario voltar ao site ter o modo escolhido recuperado!
-  button para troca de tema no mobile view.

@aosccode
@antonio-pedro99 