### PR TITLE
Melhorar o botão Voltar ao top

### DIFF
--- a/src/app/components/BackToTop/BackToTopButton.tsx
+++ b/src/app/components/BackToTop/BackToTopButton.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { ArrowUp } from 'phosphor-react';
+
+const BackToTopButton = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      if (window.pageYOffset > 300) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    window.addEventListener('scroll', toggleVisibility);
+
+    return () => {
+      window.removeEventListener('scroll', toggleVisibility);
+    };
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  };
+
+  return (
+    <button
+      className={`${
+        isVisible ? 'block' : 'hidden'
+      } dark:bg-btn dark:text-btc fixed bottom-6 right-6 bg-red-500 text-white hover:bg-red-400 p-4 rounded-full shadow-md transition-opacity duration-300`}
+      onClick={scrollToTop}
+    >
+      <ArrowUp className="h-4 w-4" />
+    </button>
+  );
+};
+
+export default BackToTopButton;

--- a/src/app/components/footer/index.tsx
+++ b/src/app/components/footer/index.tsx
@@ -5,6 +5,7 @@ import { Link } from "react-scroll";
 import NextLink from "next/link";
 import Image from "next/image";
 import { i18n } from "@/translate/i18n";
+import BackToTopButton from "../BackToTop/BackToTopButton";
 
 function Footer({ ...rest }) {
   const date = new Date();
@@ -63,7 +64,7 @@ function Footer({ ...rest }) {
                     duration={1400}
                     className="dark:text-sky-400 hover:text-black transition-colors duration-[0.3s] ease-linear cursor-pointer"
                   >
-                   {i18n.t('footer.aosc.link_2')}
+                    {i18n.t('footer.aosc.link_2')}
                   </Link>
                 </li>
                 <li>
@@ -99,7 +100,7 @@ function Footer({ ...rest }) {
 
             <div className="w-52">
               <h3 className="text-xl dark:text-white">
-              {i18n.t('footer.community.title')}
+                {i18n.t('footer.community.title')}
               </h3>
               <ul className="flex flex-col">
                 <li>
@@ -150,7 +151,7 @@ function Footer({ ...rest }) {
             </div>
             <div className="w-52">
               <h3 className="text-xl dark:text-white">
-              {i18n.t('footer.project.title')}
+                {i18n.t('footer.project.title')}
               </h3>
               <ul className="flex flex-col">
                 <li>
@@ -159,7 +160,7 @@ function Footer({ ...rest }) {
                     target="_blank"
                     className="dark:text-sky-400 hover:text-black transition-colors duration-[0.3s] ease-linear"
                   >
-                   {i18n.t('footer.project.link_1')}
+                    {i18n.t('footer.project.link_1')}
                   </NextLink>
                 </li>
                 <li>
@@ -197,15 +198,12 @@ function Footer({ ...rest }) {
               href="https://github.com/angolaosc/aosf-website/blob/main/LICENSE"
               className="dark:text-sky-400"
             >
-             {i18n.t('footer.copyright.link_2')}
+              {i18n.t('footer.copyright.link_2')}
             </NextLink>
           </p>
-          <button
-            onClick={() => animateScroll.scrollToTop()}
-            className="dark:text-white hover:text-black transition-colors duration-[0.3s] ease-linear"
-          >
-            {i18n.t('footer.button_top')}
-          </button>
+          
+          <BackToTopButton></BackToTopButton>
+
         </div>
       </div>
     </section>


### PR DESCRIPTION
Melhorar o botão voltar ao top, de modo a deixa-lo sempre disponível para o usuário no canto inferior directo da tela.
O botão ficará visível apenas quando o usuário rolar a página para baixo.